### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,17 +1,17 @@
 
 # Datatypes (KEYWORD1)
 
-bool                     KEYWORD1
-uint8_t                  KEYWORD1
-QRCode                   KEYWORD1
+bool	KEYWORD1
+uint8_t	KEYWORD1
+QRCode	KEYWORD1
 
 
 # Methods and Functions (KEYWORD2)
 
-qrcode_getBufferSize     KEYWORD2
-qrcode_initText          KEYWORD2
-qrcode_initBytes         KEYWORD2
-qrcode_getModule         KEYWORD2
+qrcode_getBufferSize	KEYWORD2
+qrcode_initText	KEYWORD2
+qrcode_initBytes	KEYWORD2
+qrcode_getModule	KEYWORD2
 
 
 # Instances (KEYWORD2)
@@ -19,13 +19,13 @@ qrcode_getModule         KEYWORD2
 
 # Constants (LITERAL1)
 
-false                    LITERAL1
-true                     LITERAL1
+false	LITERAL1
+true	LITERAL1
 
-ECC_LOW                  LITERAL1
-ECC_MEDIUM               LITERAL1
-ECC_QUARTILE             LITERAL1
-ECC_HIGH                 LITERAL1
-MODE_NUMERIC             LITERAL1
-MODE_ALPHANUMERIC        LITERAL1
-MODE_BYTE                LITERAL1
+ECC_LOW	LITERAL1
+ECC_MEDIUM	LITERAL1
+ECC_QUARTILE	LITERAL1
+ECC_HIGH	LITERAL1
+MODE_NUMERIC	LITERAL1
+MODE_ALPHANUMERIC	LITERAL1
+MODE_BYTE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords