### PR TITLE
Fixed some errors in example code of readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ API
 QRCode qrcode;
 
 // Allocate a chunk of memory to store the QR code
-uint8_t qrcodeBytes[qrcode_getBufferSize()];
+  uint8_t qrcodeBytes[qrcode_getBufferSize(3)];
 
 qrcode_initText(&qrcode, qrcodeBytes, 3, ECC_LOW, "HELLO WORLD");
 ```
@@ -48,15 +48,15 @@ The following example prints a QR code to the Serial Monitor (it likely will
 not be scannable, but is just for demonstration purposes).
 
 ```c
-for (uint8 y = 0; y < qrcode.size; y++) {
-    for (uint8 x = 0; x < qrcode.size; x++) {
-        if (qrcode_getModule(&qrcode, x, y) {
-            Serial.print("**");
-        } else {
-            Serial.print("  ");
-        }
-    }
-    Serial.print("\n");
+for (uint8_t y = 0; y < qrcode.size; y++) {
+  for (uint8_t x = 0; x < qrcode.size; x++) {
+	  if (qrcode_getModule(&qrcode, x, y)) {
+		  Serial.print("**");
+	  } else {
+		  Serial.print("  ");
+	  }
+  }
+  Serial.print("\n");
 }
 ```
 


### PR DESCRIPTION
Hello,

I'm using your QR code generator and I notice there were some errors in the example code of the readme. The list below includes the changes I have made.

- The line next line didn't had the version number:
`uint8_t qrcodeBytes[qrcode_getBufferSize(3)];`
- The tipes of the variables in the for loops appeared as uint8 instead of uint8_t, producing a compilation error.
- There was a missed parenthesis in the if inside the for loops, producing a compilation error.
`if (qrcode_getModule(&qrcode, x, y))`

I hope this corrections helps people to use this great code you have created.

Best regards.
Alberto Casas Ortiz.