### PR TITLE
Do not check for less than zero on unsigned int

### DIFF
--- a/src/qrcode.c
+++ b/src/qrcode.c
@@ -857,7 +857,7 @@ int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_
 }
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {
-    if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
+    if (x >= qrcode->size || y >= qrcode->size) {
         return false;
     }
 


### PR DESCRIPTION
This change eliminates type-limit GCC warning.